### PR TITLE
Show parking list on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
                 <div id="map" class="map"></div>
             </section>
             <section class="parking-list-section">
-                <h2>Aparcamientos cercanos</h2>
+                <h2>Aparcamientos</h2>
                 <div id="parkingList" class="parking-list"></div>
             </section>
         </main>

--- a/script.js
+++ b/script.js
@@ -65,6 +65,7 @@ async function showAllParkingLots() {
     if (parkingLots.length) {
         map.fitBounds(parkingLots.map(p => [p.lat, p.lon]), { padding: [20, 20] });
     }
+    updateParkingList(parkingLots);
 }
 
 async function searchParkingLots(userLocation) {
@@ -120,11 +121,14 @@ function updateParkingList(parkingLots) {
     parkingLots.forEach(p => {
         const item = document.createElement('div');
         item.className = 'parking-item';
-        item.innerHTML = `
+        let html = `
             <h3>${p.name}</h3>
             <p>${p.address}</p>
-            <p>Distancia: <span class="distance">${p.distance.toFixed(2)} km</span></p>
         `;
+        if (typeof p.distance === 'number') {
+            html += `<p>Distancia: <span class="distance">${p.distance.toFixed(2)} km</span></p>`;
+        }
+        item.innerHTML = html;
         parkingList.appendChild(item);
     });
 }


### PR DESCRIPTION
## Summary
- list all parking spots when the page loads
- show distance in the list only when available
- adjust page title for the parking list section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842ca5d47c4832c9b0d9897b7f3eb84